### PR TITLE
Bump GitHub workflow action to latest released versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates to GitHub Actions once per week
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,16 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run make4ht
       # uses: michal-h21/make4ht-action@master
-      uses: xu-cheng/texlive-action/full@v1
+      uses: xu-cheng/texlive-action@v2
       with:
+        scheme: full
         run: |
           make4ht -j index -la debug -d out texblend-doc.tex
     - name: Publish the web pages
-      uses:  peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         # ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         # PUBLISH_BRANCH: gh-pages


### PR DESCRIPTION
This PR bump GitHub workflow actions inside `main.yml` to latest released versions.
It also add automated dependency checking via dependabot, I hop you like this addition.